### PR TITLE
drivers/espi_hub: fix incompatible pointer type when retrieve vw

### DIFF
--- a/drivers/espi_hub.c
+++ b/drivers/espi_hub.c
@@ -526,7 +526,7 @@ int wait_for_pin_monitor_vwire(uint32_t port_pin, uint32_t exp_sts,
 }
 
 int espihub_retrieve_vw(enum espi_vwire_signal signal,
-			enum espihub_vw_level *level)
+			uint8_t *level)
 {
 	if (!hub.host_vw_ready) {
 		LOG_ERR("eSPI host not ready to receive VWs");

--- a/drivers/espi_hub.h
+++ b/drivers/espi_hub.h
@@ -240,7 +240,7 @@ int espihub_add_postcode_handler(espi_postcode_handler_t handler);
  * @retval -EINVAL if eSPI channel is not ready or 0 if success.
  */
 int espihub_retrieve_vw(enum espi_vwire_signal signal,
-			enum espihub_vw_level *level);
+			uint8_t *level);
 
 /**
  * @brief Send a virtual wire ensuring the eSPI channel is ready.


### PR DESCRIPTION
Fix passing argument of 'espihub_retrieve_vw' from incompatible pointer type, when build with other board than MEC.

The function signature of espi_receive_vwire called by espihub_retrieve_vw is "int espi_receive_vwire(const struct device * dev, enum espi_vwire_signal signal, uint8_t * level)"

Signed-off-by: Richard Yim <richardyim@ami.com>