### PR TITLE
west: Modify west to point to v2.7.3

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -28,7 +28,7 @@ manifest:
       repo-path: zephyr.git
       path: ecfwwork/zephyr_fork
       remote: zephyrproject
-      revision: v2.7-branch
+      revision: v2.7.3
       clone-depth: 1
       west-commands: scripts/west-commands.yml
 


### PR DESCRIPTION
With v2.7-branch, There may be merge issues encountered by "git am" upon applying the delta commits in zephyr_fork branch.